### PR TITLE
Update link colors

### DIFF
--- a/protocol-colors/colors/protocol-colors.android.xml
+++ b/protocol-colors/colors/protocol-colors.android.xml
@@ -37,12 +37,15 @@
     <color name="purple_dark">#4f0164</color>
 
     <color name="blue_light">#539ee9</color>
-    <color name="link-hover">#539ee9</color>
     <color name="blue">#2374c6</color>
-    <color name="link">#2374c6</color>
     <color name="blue_dark">#00458b</color>
-    <color name="link-active">#00458b</color>
 
+    <color name="link">#0060df</color>
+    <color name="link_hover">#003eaa</color>
+    <color name="link_visited">#8000d7</color>
+    <color name="link_visited-hover">#6200a4</color>
+
+    <color name="gray_lighter">#f5f5f5</color>
     <color name="gray_light">#e7e7e7</color>
     <color name="gray">#c8c8c8</color>
     <color name="gray_dark">#959595</color>

--- a/protocol-colors/colors/protocol-colors.css
+++ b/protocol-colors/colors/protocol-colors.css
@@ -36,12 +36,15 @@
   --purple-dark: #4f0164;
 
   --blue-light: #539ee9;
-  --link-hover-light: #539ee9;
   --blue: #2374c6;
-  --link: #2374c6;
   --blue-dark: #00458b;
-  --link-active-dark: #00458b;
 
+  --link: #0060df;
+  --link-hover: #003eaa;
+  --link-visited: #8000d7;
+  --link-visited-hover: #6200a4;
+
+  --gray-lighter: #f5f5f5;
   --gray-light: #e7e7e7;
   --gray: #c8c8c8;
   --gray-dark: #959595;

--- a/protocol-colors/colors/protocol-colors.gpl
+++ b/protocol-colors/colors/protocol-colors.gpl
@@ -38,12 +38,15 @@ Name: Protocol Colors
 79 1 100 Purple Dark
 
 83 158 233 Blue Light
-83 158 233 Link-hover
 35 116 198 Blue
-35 116 198 Link
 0 69 139 Blue Dark
-0 69 139 Link-active
 
+0 96 223 Link
+0 62 170 Link Hover
+128 0 215 Link Visited
+98 0 164 Link Visited-hover
+
+245 245 245 Gray Lighter
 231 231 231 Gray Light
 200 200 200 Gray
 149 149 149 Gray Dark

--- a/protocol-colors/colors/protocol-colors.js
+++ b/protocol-colors/colors/protocol-colors.js
@@ -35,12 +35,16 @@ exports.PURPLE = '#6e008b';
 exports.PURPLE_DARK = '#4f0164';
 
 exports.BLUE_LIGHT = '#539ee9';
-exports.LINK_HOVER = '#539ee9';
 exports.BLUE = '#2374c6';
-exports.LINK = '#2374c6';
 exports.BLUE_DARK = '#00458b';
-exports.LINK_ACTIVE = '#00458b';
 
+exports.LINK = '#0060df';
+exports.LINK_HOVER = '#003eaa';
+exports.LINK_VISITED = '#8000d7';
+exports.LINK_VISITED-HOVER = '#6200a4';
+
+exports.GRAY_LIGHTER = '#f5f5f5';
 exports.GRAY_LIGHT = '#e7e7e7';
 exports.GRAY = '#c8c8c8';
 exports.GRAY_DARK = '#959595';
+

--- a/protocol-colors/colors/protocol-colors.json
+++ b/protocol-colors/colors/protocol-colors.json
@@ -12,50 +12,48 @@
     }
   },
   "cyan": {
-    "light":  {"hex": "#a2ffff"},
+    "light": {"hex": "#a2ffff"},
     "base": {"hex": "#00ffff"},
-    "dark":   {"hex": "#00e5e5"}
+    "dark": {"hex": "#00e5e5"}
   },
   "yellow": {
-    "light":  {"hex": "#fff9a3"},
+    "light": {"hex": "#fff9a3"},
     "base": {"hex": "#fff44f"},
-    "dark":   {"hex": "#f7e800"}
+    "dark": {"hex": "#f7e800"}
   },
   "red": {
-    "light":  {"hex": "#fe7c87"},
+    "light": {"hex": "#fe7c87"},
     "base": {"hex": "#ff4f5e"},
-    "dark":   {"hex": "#e53c4a"}
+    "dark": {"hex": "#e53c4a"}
   },
   "green": {
-    "light":  {"hex": "#adffdf"},
+    "light": {"hex": "#adffdf"},
     "base": {"hex": "#54ffbd"},
-    "dark":   {"hex": "#2ce69e"}
+    "dark": {"hex": "#2ce69e"}
   },
   "teal": {
-    "light":  {"hex": "#25bcbc"},
+    "light": {"hex": "#25bcbc"},
     "base": {"hex": "#0f8f8f"},
-    "dark":   {"hex": "#005e5e"}
+    "dark": {"hex": "#005e5e"}
   },
   "purple": {
-    "light":  {"hex": "#9f54b2"},
+    "light": {"hex": "#9f54b2"},
     "base": {"hex": "#6e008b"},
-    "dark":   {"hex": "#4f0164"}
+    "dark": {"hex": "#4f0164"}
   },
   "blue": {
-    "light":  {
-      "hex": "#539ee9",
-      "map": "link-hover"
-    },
-    "base": {
-      "hex": "#2374c6",
-      "map": "link"
-    },
-    "dark":   {
-      "hex": "#00458b",
-      "map": "link-active"
-    }
+    "light": {"hex": "#539ee9"},
+    "base": {"hex": "#2374c6"},
+    "dark": {"hex": "#00458b"}
+  },
+  "link": {
+    "base": {"hex": "#0060df"},
+    "hover": {"hex": "#003eaa"},
+    "visited": {"hex": "#8000d7"},
+    "visited-hover": {"hex": "#6200a4"}
   },
   "gray": {
+    "lighter": {"hex": "#f5f5f5"},
     "light":  {"hex": "#e7e7e7"},
     "base": {"hex": "#c8c8c8"},
     "dark":   {"hex": "#959595"}

--- a/protocol-colors/colors/protocol-colors.less
+++ b/protocol-colors/colors/protocol-colors.less
@@ -35,12 +35,15 @@
 @color-purple-dark: #4f0164;
 
 @color-blue-light: #539ee9;
-@color-blue-light: #539ee9;
 @color-blue: #2374c6;
-@color-link: #2374c6;
-@color-blue-dark: #00458b;
 @color-blue-dark: #00458b;
 
+@color-link: #0060df;
+@color-link-hover: #003eaa;
+@color-link-visited: #8000d7;
+@color-link-visited-hover: #6200a4;
+
+@color-gray-lighter: #f5f5f5;
 @color-gray-light: #e7e7e7;
 @color-gray: #c8c8c8;
 @color-gray-dark: #959595;

--- a/protocol-colors/colors/protocol-colors.scss
+++ b/protocol-colors/colors/protocol-colors.scss
@@ -35,12 +35,15 @@ $color-purple: #6e008b;
 $color-purple-dark: #4f0164;
 
 $color-blue-light: #539ee9;
-$color-link-hover: #539ee9;
 $color-blue: #2374c6;
-$color-link: #2374c6;
 $color-blue-dark: #00458b;
-$color-link-active: #00458b;
 
+$color-link: #0060df;
+$color-link-hover: #003eaa;
+$color-link-visited: #8000d7;
+$color-link-visited-hover: #6200a4;
+
+$color-gray-lighter: #f5f5f5;
 $color-gray-light: #e7e7e7;
 $color-gray: #c8c8c8;
 $color-gray-dark: #959595;

--- a/protocol-colors/colors/protocol-colors.soc
+++ b/protocol-colors/colors/protocol-colors.soc
@@ -42,12 +42,15 @@
   <draw:color draw:name="purple-dark" draw:color="#4f0164" />
 
   <draw:color draw:name="blue-light" draw:color="#539ee9" />
-  <draw:color draw:name="link-hover" draw:color="#539ee9" />
   <draw:color draw:name="blue" draw:color="#2374c6" />
-  <draw:color draw:name="link" draw:color="#2374c6" />
   <draw:color draw:name="blue-dark" draw:color="#00458b" />
-  <draw:color draw:name="link-active" draw:color="#00458b" />
 
+  <draw:color draw:name="link" draw:color="#0060df" />
+  <draw:color draw:name="link-hover" draw:color="#003eaa" />
+  <draw:color draw:name="link-visited" draw:color="#8000d7" />
+  <draw:color draw:name="link-visited-hover" draw:color="#6200a4" />
+
+  <draw:color draw:name="gray-lighter" draw:color="#f5f5f5" />
   <draw:color draw:name="gray-light" draw:color="#e7e7e7" />
   <draw:color draw:name="gray" draw:color="#c8c8c8" />
   <draw:color draw:name="gray-dark" draw:color="#959595" />

--- a/protocol-colors/colors/protocol-colors.swift
+++ b/protocol-colors/colors/protocol-colors.swift
@@ -38,12 +38,15 @@ extension UIColor {
         static let Purpledark = UIColor(rgb: 0x4f0164)
 
         static let Bluelight = UIColor(rgb: 0x539ee9)
-        static let Link-hover = UIColor(rgb: 0x539ee9)
         static let Blue = UIColor(rgb: 0x2374c6)
-        static let Link = UIColor(rgb: 0x2374c6)
         static let Bluedark = UIColor(rgb: 0x00458b)
-        static let Link-active = UIColor(rgb: 0x00458b)
 
+        static let Link = UIColor(rgb: 0x0060df)
+        static let Linkhover = UIColor(rgb: 0x003eaa)
+        static let Linkvisited = UIColor(rgb: 0x8000d7)
+        static let Linkvisited-hover = UIColor(rgb: 0x6200a4)
+
+        static let Graylighter = UIColor(rgb: 0xf5f5f5)
         static let Graylight = UIColor(rgb: 0xe7e7e7)
         static let Gray = UIColor(rgb: 0xc8c8c8)
         static let Graydark = UIColor(rgb: 0x959595)

--- a/protocol-colors/protocol-colors.js
+++ b/protocol-colors/protocol-colors.js
@@ -35,12 +35,15 @@ exports.PURPLE = '#6e008b';
 exports.PURPLE_DARK = '#4f0164';
 
 exports.BLUE_LIGHT = '#539ee9';
-exports.LINK_HOVER = '#539ee9';
 exports.BLUE = '#2374c6';
-exports.LINK = '#2374c6';
 exports.BLUE_DARK = '#00458b';
-exports.LINK_ACTIVE = '#00458b';
 
+exports.LINK = '#0060df';
+exports.LINK_HOVER = '#003eaa';
+exports.LINK_VISITED = '#8000d7';
+exports.LINK_VISITED_HOVER = '#6200a4';
+
+exports.GRAY_LIGHTER = '#f5f5f5';
 exports.GRAY_LIGHT = '#e7e7e7';
 exports.GRAY = '#c8c8c8';
 exports.GRAY_DARK = '#959595';

--- a/protocol-colors/protocol-colors.scss
+++ b/protocol-colors/protocol-colors.scss
@@ -35,12 +35,15 @@ $color-purple: #6e008b;
 $color-purple-dark: #4f0164;
 
 $color-blue-light: #539ee9;
-$color-link-hover: #539ee9;
 $color-blue: #2374c6;
-$color-link: #2374c6;
 $color-blue-dark: #00458b;
-$color-link-active: #00458b;
 
+$color-link: #0060df;
+$color-link-hover: #003eaa;
+$color-link-visited: #8000d7;
+$color-link-visited-hover: #6200a4;
+
+$color-gray-lighter: #f5f5f5;
 $color-gray-light: #e7e7e7;
 $color-gray: #c8c8c8;
 $color-gray-dark: #959595;


### PR DESCRIPTION
This updates to the final link colors derived from Photon. For some of these formats I'm not sure I've done it right, I was just following what seemed to be the pattern. Let me know if I've broken something or missed something.

This also adds a "gray-lighter" value of #f5f5f5 that has been appearing in some of the mockups, figured we might as well make it official.

We should get this sorted before https://github.com/mozilla/protocol/pull/47 merges.